### PR TITLE
Fix integer division

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+package-lock.json
 perguntas.txt

--- a/server/examples/square-repeat-function.vm:Zone.Identifier
+++ b/server/examples/square-repeat-function.vm:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=about:internet

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -105,7 +105,7 @@ module.exports = {
                 var m = operand_stack.pop()
                 if (n == 0) error = 'Division By Zero: div'
                 else if(Number.isInteger(n) && Number.isInteger(m))
-                  operand_stack.push(m / n)
+                  operand_stack.push((m / n) | 0)
                 else error = 'Illegal Operand: div - elements not Integer'
               } else error = 'Segmentation Fault: div - elements missing'
               break


### PR DESCRIPTION
`div` is actually not performing integer division, which it should, in contrast to `fdiv`.

Before:
```
pushi 3
pushi 2
div
writei
```
> Result: Illegal Operand: writei - element not Integer
 
Happens because `div` yields `1.5` to the stack.

After:
```
pushi 3
pushi 2
div
writei
```
> Result: 1
```
pushi 3
pushi 2
fdiv
writef
```
> Result: 1.5